### PR TITLE
Added interactive commands warning

### DIFF
--- a/src/resources/views/livewire/terminal.blade.php
+++ b/src/resources/views/livewire/terminal.blade.php
@@ -41,6 +41,8 @@
 
             terminal.writeln('Running Laravel \x1b[93;1mv{{ Illuminate\Foundation\Application::VERSION }}\x1b[0m (PHP \x1b[93;1mv{{ PHP_VERSION }}\x1b[0m) (Shell: \x1b[34;1m{{ explode(' ', $commandLine)[0] }}\x1b[0m)\r\n');
 
+            terminal.writeln('\x1b[31;1mWarning:\x1b[0m Running interactive commands \x1b[31;1mwill hang your server\x1b[0m indefinitely until restarted.')
+
             terminal.onData(e => {
                 if (!terminalEnabled) return false;
                 switch (e) {

--- a/src/resources/views/livewire/terminal.blade.php
+++ b/src/resources/views/livewire/terminal.blade.php
@@ -5,6 +5,14 @@
         let command = '';
         let directory = '{{ $currentDirectory }}';
 
+        const interactiveCommands = [
+            'php artisan tinker',
+            'php artisan serve',
+            'php artisan queue:work',
+            'php artisan queue:listen',
+            'php artisan schedule:work',
+        ];
+
         document.addEventListener('DOMContentLoaded', () => {
             const terminal = new window.Terminal({
                 fontFamily: '"Cascadia Code", Menlo, monospace',
@@ -107,6 +115,12 @@
 
             if (command.length > 0) {
                 terminal.writeln('');
+
+                if (interactiveCommands.includes(text)) {
+                    terminal.writeln(`\x1b[31;1mError:\x1b[0m Running interactive commands \x1b[31;1mwill hang your server\x1b[0m indefinitely until restarted.`);
+                    prompt(terminal);
+                    return false;
+                }
 
                 @this.runCommand(text);
             } else {


### PR DESCRIPTION
Until custom commands that don't rely on PHP's `exec` function for interactive commands, such as `php artisan tinker` are developed, I have added a warning.