### PR TITLE
Renamed terminal component.

### DIFF
--- a/src/LaravelShellServiceProvider.php
+++ b/src/LaravelShellServiceProvider.php
@@ -75,6 +75,6 @@ class LaravelShellServiceProvider extends ServiceProvider
      */
     protected function registerLivewireComponents(): void
     {
-        Livewire::component('terminal', \Jakyeru\LaravelShell\Http\Livewire\Terminal::class);
+        Livewire::component('laravel-shell::terminal', \Jakyeru\LaravelShell\Http\Livewire\Terminal::class);
     }
 }


### PR DESCRIPTION
Renamed the terminal component from `terminal` to `laravel-shell::terminal` to prevent conflicts with other Livewire components that might be called `terminal`.