### PR TITLE
Fix bash syntax error on concatenated command string

### DIFF
--- a/src/Http/Livewire/Terminal.php
+++ b/src/Http/Livewire/Terminal.php
@@ -86,7 +86,7 @@ class Terminal extends Component
                 $this->commandLine = 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe -Command "cd ' . $this->currentDirectory . ';';
             } else if (php_uname('s') === 'Linux' || php_uname('s') === 'Darwin') {
                 $this->currentDirectory = getcwd();
-                $this->commandLine = 'bash -c "cd ' . $this->currentDirectory . '";';
+                $this->commandLine = 'bash -c "cd ' . $this->currentDirectory . ';';
             }
 
             if ($dispatch) {


### PR DESCRIPTION
Commit 8ebbd65 changed the way how the final Bash command string is constructed.

An extra `"` symbol breaks the resulting shell command, removing it results in a valid command.